### PR TITLE
Make npm publish non-blocking

### DIFF
--- a/.github/workflows/buildBinaries.yml
+++ b/.github/workflows/buildBinaries.yml
@@ -122,6 +122,7 @@ jobs:
         working-directory: ts-proto
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true
         run: npm publish
 
       - name: Build binary for Linux AMD64


### PR DESCRIPTION
Allow npm publish to fail without failing the release workflow, so binaries/assets still publish.