### PR TITLE
Avoid duplicate build runs on release

### DIFF
--- a/.github/workflows/buildBinaries.yml
+++ b/.github/workflows/buildBinaries.yml
@@ -1,9 +1,6 @@
 name: 1.Build Binaries
 
 on:
-  push:
-      tags:
-      - '*' # Trigger on tag creation
   release:
     types: [published, prereleased]
   workflow_dispatch:


### PR DESCRIPTION
Remove tag-push trigger so 1.Build Binaries runs once per release.