### PR TITLE
Run build only on prerelease

### DIFF
--- a/.github/workflows/buildBinaries.yml
+++ b/.github/workflows/buildBinaries.yml
@@ -2,7 +2,7 @@ name: 1.Build Binaries
 
 on:
   release:
-    types: [published, prereleased]
+    types: [prereleased]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Avoid duplicate asset publishing by running 1.Build Binaries only on prerelease events (promotion to published will not retrigger).