### PR TITLE
fix(ci): bump Node to 24 in buildBinaries workflow

### DIFF
--- a/.github/workflows/buildBinaries.yml
+++ b/.github/workflows/buildBinaries.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Set up Go environment


### PR DESCRIPTION
## Summary
Node 22.22.2 is the root cause — its tool-cache layout triggers `Cannot find module 'promise-retry'` when the global npm is rebuilt, blocking the workflow before any repo code runs. Bumping to Node 24 (where the issue is resolved) is more future-proof than pinning npm per @genaris's recommendation.

Failing run: https://github.com/verana-labs/verana/actions/runs/24665057398

## Test plan
- [ ] buildBinaries workflow runs green on this PR