### PR TITLE
test: comprehensive behavioral test overhaul (issue #292)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ ts-proto/test/out/
 
 # Compiled binaries in ts-proto
 ts-proto/cmd
+
+# Git worktrees (subagent-driven dev workflow)
+.worktrees/

--- a/docs/superpowers/specs/2026-05-05-comprehensive-test-overhaul-design.md
+++ b/docs/superpowers/specs/2026-05-05-comprehensive-test-overhaul-design.md
@@ -1,0 +1,265 @@
+# Comprehensive Behavioral Test Overhaul
+
+**Date:** 2026-05-05
+**Issue:** [#292](https://github.com/verana-labs/verana/issues/292)
+**Sub-issue:** [#286](https://github.com/verana-labs/verana/issues/286) (TS smoke tests for CreateRootPermission + RenewPermissionVP)
+**Spec:** https://verana-labs.github.io/verifiable-trust-vpr-spec/
+
+---
+
+## Problem Statement
+
+The current `MockBankKeeper` is a no-op — `SendCoinsFromAccountToModule` returns `nil` and records nothing. Fee math is never exercised in unit tests. A wrong calculation passes because the mock silently eats every `SendCoins` call. This was observed: incorrect math was introduced, tests passed; math was corrected, tests still passed. The tests provided no signal.
+
+Additional gaps:
+- State assertions check only the fields the test author thought to check, not the full struct
+- Negative cases are ad hoc — not systematically derived from the spec's precondition list
+- Expected financial values are derived from the same implementation under test (self-validating, catches nothing)
+- TS-proto journey files mix `LEGACY_AMINO` and `DIRECT` sign modes inconsistently
+
+---
+
+## Approach: Per-module Fixture + Stateful Bank Mock
+
+### Chosen approach
+
+**Approach B — Per-module `Fixture` struct with embedded financial assertions.**
+
+Each module gets a `x/{module}/keeper/fixture_test.go` that owns the full test environment and exposes typed assertion helpers. Expected values are computed from spec formulas written as pure Go functions, independent of the implementation.
+
+### Rejected alternatives
+
+- **Approach A (upgraded shared mock):** Simpler, but doesn't force independent expected value computation — a test author could still derive expectations from the same wrong formula.
+- **Approach C (`simapp` integration tests):** Most realistic, but 10–20x slower per test, much heavier setup, overkill for behavioral unit testing.
+
+---
+
+## Architecture
+
+### 1. `StatefulBankMock` (`testutil/keeper/bank.go`)
+
+New file. All fixture-based tests use this instead of the existing no-op `MockBankKeeper`. The no-op mock remains for legacy test files until they are migrated.
+
+```go
+type StatefulBankMock struct {
+    mu       sync.Mutex
+    balances map[string]map[string]int64 // addr -> denom -> amount
+    calls    []BankCall                  // full call history for assertions
+}
+
+type BankCall struct {
+    Method string
+    From   string
+    To     string
+    Amount sdk.Coins
+}
+
+func (m *StatefulBankMock) SetBalance(addr, denom string, amount int64)
+func (m *StatefulBankMock) GetBalance(addr, denom string) int64
+func (m *StatefulBankMock) RequireBalanceDelta(t, addr, denom string, delta int64)
+func (m *StatefulBankMock) SendCoinsFromAccountToModule(...) error  // enforces deduction
+func (m *StatefulBankMock) SendCoinsFromModuleToAccount(...) error  // enforces balance
+func (m *StatefulBankMock) SendCoins(...) error
+func (m *StatefulBankMock) HasBalance(...) bool
+// ... full BankKeeper interface
+```
+
+`SendCoinsFromAccountToModule` returns `sdkerrors.ErrInsufficientFunds` if the sender balance is insufficient. Every call is recorded in `calls`.
+
+### 2. Per-module `Fixture` (`x/{module}/keeper/fixture_test.go`)
+
+```go
+type Fixture struct {
+    t    *testing.T
+    K    keeper.Keeper
+    MS   types.MsgServer
+    Ctx  sdk.Context
+    Bank *testutil.StatefulBankMock
+    // module-specific mocks:
+    // CSKeeper  *testutil.MockCredentialSchemaKeeper  (perm module)
+    // TRKeeper  *testutil.MockTrustRegistryKeeper     (perm, cs modules)
+    // etc.
+}
+
+func NewFixture(t *testing.T) *Fixture
+
+// Balance helpers
+func (f *Fixture) SetBalance(addr, denom string, amount int64)
+func (f *Fixture) RequireBalanceDelta(addr, denom string, delta int64)
+func (f *Fixture) RequireNoBalanceChange(addr string)
+
+// State helpers
+func (f *Fixture) RequireObjectCount(n int)                        // module-specific count helper
+func (f *Fixture) RequirePermission(id uint64, want types.Permission) // typed per-module; full require.Equal
+
+// Time helpers
+func (f *Fixture) SetBlockTime(t time.Time)
+func (f *Fixture) AdvanceTime(d time.Duration)
+
+// Invariant helper
+func (f *Fixture) RequireInvariant()  // module-specific invariant check
+```
+
+### 3. Spec formula functions (per test file)
+
+Written at the top of each test file, pure Go, no keeper imports. Named after the spec ID they implement.
+
+```go
+// specPermStartVPFees returns the validation fee deduction per MOD-PERM-MSG-1-2-3.
+// validationFees is validator_perm.validation_fees, trustUnitPrice from params.
+func specPermStartVPFees(validationFees, trustUnitPrice uint64) uint64 {
+    return validationFees * trustUnitPrice
+}
+
+// specPermStartVPDeposit returns the trust deposit increment per MOD-PERM-MSG-1-2-3.
+func specPermStartVPDeposit(validationFees, trustUnitPrice, depositRatio uint64) uint64 {
+    return (validationFees * trustUnitPrice * depositRatio) / 100
+}
+```
+
+The test assertion:
+```go
+f.RequireBalanceDelta(applicant, denom, -int64(specPermStartVPFees(valFees, tup)))
+```
+
+If the implementation uses a different formula, this breaks. That is the point.
+
+### 4. Precondition matrix pattern
+
+Every message test function follows this structure:
+
+```go
+func TestMsgStartPermissionVP(t *testing.T) {
+    // --- Happy path ---
+    t.Run("MOD-PERM-MSG-1: valid ISSUER request", func(t *testing.T) {
+        f := NewFixture(t)
+        f.SetBalance(applicant, denom, 10_000)
+        // ... setup ...
+        resp, err := f.MS.StartPermissionVP(f.Ctx, msg)
+        require.NoError(t, err)
+        require.NotZero(t, resp.Id)
+        f.RequireBalanceDelta(applicant, denom, -int64(specPermStartVPFees(...)))
+        f.RequireState(resp.Id, expectedPerm)  // full struct comparison
+        f.RequireInvariant()
+    })
+
+    // --- Negative cases, one per spec precondition ---
+    t.Run("MOD-PERM-MSG-1-2-1: fails if operator not authorized", func(t *testing.T) {
+        f := NewFixture(t)
+        _, err := f.MS.StartPermissionVP(f.Ctx, msgWithBadOperator)
+        require.ErrorContains(t, err, "authorization check failed")
+        f.RequireObjectCount(0)
+        f.RequireNoBalanceChange(applicant)
+    })
+
+    t.Run("MOD-PERM-MSG-1-2-2a: fails if validator perm not found", func(t *testing.T) { ... })
+    t.Run("MOD-PERM-MSG-1-2-2b: fails if validator perm not ACTIVE", func(t *testing.T) { ... })
+    t.Run("MOD-PERM-MSG-1-2-2c: fails if perm type incompatible", func(t *testing.T) { ... })
+    t.Run("MOD-PERM-MSG-1-2-4: fails on overlap", func(t *testing.T) { ... })
+
+    // --- Edge cases ---
+    t.Run("overflow: fees * trustUnitPrice exceeds uint64", func(t *testing.T) { ... })
+    t.Run("zero fees: no bank transfer occurs", func(t *testing.T) { ... })
+}
+```
+
+Rules:
+- Every negative case: assert error, assert zero state written, assert no balance change
+- Every happy path: full struct assertion + balance delta + invariant
+- Each `t.Run` name references the spec ID where applicable
+
+---
+
+## TS-Proto Strategy
+
+### Sign mode standardization
+
+All journey files must use `createAccountFromMnemonic` (`Secp256k1HdWallet` — LEGACY_AMINO). Files currently using `createDirectAccountFromMnemonic` must be updated. This is Keplr's sign mode and the one the frontend uses.
+
+### Issue #286 (Step 5)
+
+Two deliverables:
+1. `permCreateRootPermission.ts` — verify sign mode is LEGACY_AMINO (currently correct, confirm)
+2. `permRenewPermissionVP.ts` — new file, same pattern as existing journeys
+
+Both: build message in TS → sign LEGACY_AMINO → broadcast → assert no error. No business logic assertions.
+
+### Complete journey coverage gaps
+
+| Module | Journey files to add |
+|--------|---------------------|
+| PERM | `permRenewPermissionVP.ts` |
+| CS | `csCreateSchemaAuthorizationPolicy.ts`, `csIncreaseActiveSAPVersion.ts`, `csRevokeSchemaAuthorizationPolicy.ts` |
+| TD | `tdSlashTrustDeposit.ts`, `tdBurnEcosystemSlashedTrustDeposit.ts` |
+| DE | `deGrantVsOperatorAuthorization.ts`, `deRevokeVsOperatorAuthorization.ts`, `deGrantExchangeRateAuthorization.ts`, `deRevokeExchangeRateAuthorization.ts` |
+| XR | `xrCreateExchangeRate.ts`, `xrUpdateExchangeRate.ts`, `xrToggleExchangeRateState.ts` |
+
+`runAll.ts` updated to include all new journeys in dependency order.
+
+---
+
+## Execution Order
+
+Work is one message at a time. Step 0 is a hard gate.
+
+| Step | Work unit | Type |
+|------|-----------|------|
+| 0 | `StatefulBankMock` in `testutil/keeper/bank.go` + its own tests | Infrastructure |
+| 1 | TD: `ReclaimTrustDepositYield` | Unit |
+| 2 | TD: `SlashTrustDeposit` | Unit |
+| 3 | TD: `RepaySlashedTrustDeposit` | Unit |
+| 4 | TD: `BurnEcosystemSlashedTrustDeposit` | Unit |
+| 5 | TS #286: sign mode fix + `permRenewPermissionVP.ts` | TS-proto |
+| 6 | TR: `CreateTrustRegistry` | Unit |
+| 7 | TR: `AddGovernanceFrameworkDocument` | Unit |
+| 8 | TR: `IncreaseActiveGovernanceFrameworkVersion` | Unit |
+| 9 | TR: `UpdateTrustRegistry` | Unit |
+| 10 | TR: `ArchiveTrustRegistry` | Unit |
+| 11 | CS: `CreateCredentialSchema` | Unit |
+| 12 | CS: `UpdateCredentialSchema` | Unit |
+| 13 | CS: `ArchiveCredentialSchema` | Unit |
+| 14 | CS: `CreateSchemaAuthorizationPolicy` | Unit |
+| 15 | CS: `IncreaseActiveSAPVersion` | Unit |
+| 16 | CS: `RevokeSchemaAuthorizationPolicy` | Unit |
+| 17 | DE: `GrantOperatorAuthorization` | Unit |
+| 18 | DE: `RevokeOperatorAuthorization` | Unit |
+| 19 | DE: `GrantVsOperatorAuthorization` | Unit |
+| 20 | DE: `RevokeVsOperatorAuthorization` | Unit |
+| 21 | PERM: `CreateRootPermission` | Unit |
+| 22 | PERM: `StartPermissionVP` | Unit |
+| 23 | PERM: `RenewPermissionVP` | Unit |
+| 24 | PERM: `SetPermissionVPToValidated` | Unit |
+| 25 | PERM: `CancelPermissionVPLastRequest` | Unit |
+| 26 | PERM: `AdjustPermission` | Unit |
+| 27 | PERM: `RevokePermission` | Unit |
+| 28 | PERM: `CreateOrUpdatePermissionSession` | Unit |
+| 29 | PERM: `SlashPermissionTrustDeposit` | Unit |
+| 30 | PERM: `RepayPermissionSlashedTrustDeposit` | Unit |
+| 31 | PERM: `SelfCreatePermission` | Unit |
+| 32 | XR: `CreateExchangeRate`, `UpdateExchangeRate`, `ToggleExchangeRateState` | Unit |
+| 33 | DI: `StoreDigest` | Unit |
+| 34 | Fill remaining TS-proto journey gaps | TS-proto |
+
+---
+
+## "Done" Criteria
+
+### Per message (unit test)
+- [ ] Happy path: full field-by-field state assertion (`require.Equal` on complete struct)
+- [ ] Happy path: exact balance delta via independently-computed spec formula function
+- [ ] Happy path: module-level invariant check passes
+- [ ] One `t.Run` per spec precondition: correct error string, zero state written, no balance change
+- [ ] Edge cases: overflow inputs, boundary timestamps, zero fees, max values per spec
+
+### Per message (ts-proto)
+- [ ] Journey file exists using `Secp256k1HdWallet` (LEGACY_AMINO)
+- [ ] Builds message, signs, broadcasts, asserts no error
+
+---
+
+## Source of Truth
+
+All precondition IDs, fee formulas, and state field requirements come from the spec:
+https://verana-labs.github.io/verifiable-trust-vpr-spec/
+
+If spec and implementation disagree, spec wins. Tests are written to the spec, not to the implementation.

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -66,12 +66,33 @@ func DefaultModuleAddrs() map[string]sdk.AccAddress {
 
 // --- Mock-only helpers (not part of the BankKeeper interface) ---
 
+// SetBalance sets the balance for (addr, denom) and snapshots it as the
+// baseline used by RequireBalanceDelta. Subsequent SetBalance calls on the
+// same (addr, denom) reset both current and baseline.
 func (m *StatefulBankMock) SetBalance(addr sdk.AccAddress, denom string, amount int64) {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := addr.String()
+	if m.balances[key] == nil {
+		m.balances[key] = map[string]int64{}
+	}
+	if m.baseline[key] == nil {
+		m.baseline[key] = map[string]int64{}
+	}
+	m.balances[key][denom] = amount
+	m.baseline[key][denom] = amount
 }
 
+// BalanceOf returns the int64 balance for (addr, denom). It is the
+// assertion-friendly sibling of GetBalance (which returns sdk.Coin to
+// satisfy the BankKeeper interface).
 func (m *StatefulBankMock) BalanceOf(addr sdk.AccAddress, denom string) int64 {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if d, ok := m.balances[addr.String()]; ok {
+		return d[denom]
+	}
+	return 0
 }
 
 func (m *StatefulBankMock) Calls() []BankCall {

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -96,12 +97,37 @@ func (m *StatefulBankMock) BalanceOf(addr sdk.AccAddress, denom string) int64 {
 	return 0
 }
 
+// Calls returns a defensive copy of the recorded call history. Tests can
+// mutate the returned slice without affecting the mock.
 func (m *StatefulBankMock) Calls() []BankCall {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]BankCall, len(m.calls))
+	copy(out, m.calls)
+	return out
 }
 
+// RequireBalanceDelta asserts that (current - baseline) for (addr, denom)
+// equals delta. The baseline is whatever SetBalance most recently wrote
+// for (addr, denom); if SetBalance was never called for that pair, the
+// baseline is 0.
 func (m *StatefulBankMock) RequireBalanceDelta(t require.TestingT, addr sdk.AccAddress, denom string, delta int64) {
-	panic("not implemented")
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
+	m.mu.Lock()
+	current, baseline := int64(0), int64(0)
+	if d, ok := m.balances[addr.String()]; ok {
+		current = d[denom]
+	}
+	if d, ok := m.baseline[addr.String()]; ok {
+		baseline = d[denom]
+	}
+	m.mu.Unlock()
+	got := current - baseline
+	require.Equalf(t, delta, got,
+		"balance delta for %s [%s]: want %d, got %d (baseline=%d, current=%d)",
+		addr.String(), denom, delta, got, baseline, current)
 }
 
 // --- BankKeeper interface methods ---
@@ -188,20 +214,49 @@ func (m *StatefulBankMock) BurnCoins(ctx context.Context, name string, amt sdk.C
 	return nil
 }
 
+// HasBalance returns true iff addr's balance of amt.Denom is at least amt.Amount.
 func (m *StatefulBankMock) HasBalance(ctx context.Context, addr sdk.AccAddress, amt sdk.Coin) bool {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	have := int64(0)
+	if d, ok := m.balances[addr.String()]; ok {
+		have = d[amt.Denom]
+	}
+	return have >= nonNegativeAmount(amt)
 }
 
+// GetBalance returns the sdk.Coin for (addr, denom). Unset balances yield a
+// zero coin in the requested denom (denom preserved).
 func (m *StatefulBankMock) GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	have := int64(0)
+	if d, ok := m.balances[addr.String()]; ok {
+		have = d[denom]
+	}
+	return sdk.NewCoin(denom, math.NewInt(have))
 }
 
+// GetAllBalances returns all non-zero balances held by addr, sorted in
+// canonical sdk.Coins order. Zero-amount denoms are omitted.
 func (m *StatefulBankMock) GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := sdk.Coins{}
+	if d, ok := m.balances[addr.String()]; ok {
+		for denom, amt := range d {
+			if amt > 0 {
+				out = append(out, sdk.NewCoin(denom, math.NewInt(amt)))
+			}
+		}
+	}
+	return out.Sort()
 }
 
+// SpendableCoins matches GetAllBalances for the mock — there are no
+// vesting or escrow constraints in the test surface.
 func (m *StatefulBankMock) SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins {
-	panic("not implemented")
+	return m.GetAllBalances(ctx, addr)
 }
 
 // resolveModule returns the module account address for name, or panics if

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 )
@@ -105,8 +106,17 @@ func (m *StatefulBankMock) RequireBalanceDelta(t require.TestingT, addr sdk.AccA
 
 // --- BankKeeper interface methods ---
 
+// SendCoins moves amt from->to. It is atomic: if any denom is insufficient,
+// no balance is mutated and sdkerrors.ErrInsufficientFunds is returned.
 func (m *StatefulBankMock) SendCoins(ctx context.Context, from, to sdk.AccAddress, amt sdk.Coins) error {
-	panic("not implemented")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fromKey, toKey := from.String(), to.String()
+	if err := m.transfer(fromKey, toKey, amt); err != nil {
+		return err
+	}
+	m.calls = append(m.calls, BankCall{Method: "SendCoins", From: fromKey, To: toKey, Amount: copyCoins(amt)})
+	return nil
 }
 
 func (m *StatefulBankMock) SendCoinsFromAccountToModule(ctx context.Context, sender sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
@@ -149,6 +159,45 @@ func (m *StatefulBankMock) resolveModule(name string) sdk.AccAddress {
 		panic(fmt.Sprintf("StatefulBankMock: unknown module %q (register it in NewStatefulBankMock's modAddrs)", name))
 	}
 	return a
+}
+
+// transfer is the atomic core. It assumes m.mu is held. It first verifies
+// the sender has enough of every denom, then performs all debits and
+// credits. Returns sdkerrors.ErrInsufficientFunds (wrapped with detail) on
+// failure without mutating any balance.
+func (m *StatefulBankMock) transfer(fromKey, toKey string, amt sdk.Coins) error {
+	for _, c := range amt {
+		need := nonNegativeAmount(c)
+		have := int64(0)
+		if d, ok := m.balances[fromKey]; ok {
+			have = d[c.Denom]
+		}
+		if have < need {
+			return sdkerrors.ErrInsufficientFunds.Wrapf(
+				"%s: have %d%s, need %d%s", fromKey, have, c.Denom, need, c.Denom)
+		}
+	}
+	for _, c := range amt {
+		amount := nonNegativeAmount(c)
+		if m.balances[fromKey] == nil {
+			m.balances[fromKey] = map[string]int64{}
+		}
+		if m.balances[toKey] == nil {
+			m.balances[toKey] = map[string]int64{}
+		}
+		m.balances[fromKey][c.Denom] -= amount
+		m.balances[toKey][c.Denom] += amount
+	}
+	return nil
+}
+
+// copyCoins returns a shallow copy of the slice header so that the
+// caller-supplied amt cannot be mutated post-record. sdk.Coin elements are
+// value-copied; their math.Int internals are immutable.
+func copyCoins(amt sdk.Coins) sdk.Coins {
+	out := make(sdk.Coins, len(amt))
+	copy(out, amt)
+	return out
 }
 
 // nonNegativeAmount returns coin.Amount.Int64() and panics if it would

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"sort"
 	"sync"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -129,16 +128,6 @@ func (m *StatefulBankMock) resolveModule(name string) sdk.AccAddress {
 		panic(fmt.Sprintf("StatefulBankMock: unknown module %q (register it in NewStatefulBankMock's modAddrs)", name))
 	}
 	return a
-}
-
-// sortedDenoms returns coin denoms sorted ascending — matches sdk.Coins ordering.
-func sortedDenoms(c sdk.Coins) []string {
-	d := make([]string, 0, len(c))
-	for _, coin := range c {
-		d = append(d, coin.Denom)
-	}
-	sort.Strings(d)
-	return d
 }
 
 // nonNegativeAmount returns coin.Amount.Int64() and panics if it would

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -33,7 +33,7 @@ type StatefulBankMock struct {
 	mu       sync.Mutex
 	balances map[string]map[string]int64 // addr -> denom -> amount
 	baseline map[string]map[string]int64 // addr -> denom -> baseline (set by SetBalance)
-	modAddrs map[string]sdk.AccAddress   // module name -> module account address
+	modAddrs map[string]sdk.AccAddress   // module name -> module account address (set once at construction; read-only thereafter, so resolveModule reads it without taking m.mu)
 	calls    []BankCall
 }
 
@@ -285,9 +285,10 @@ func (m *StatefulBankMock) transfer(fromKey, toKey string, amt sdk.Coins) error 
 				"%s: have %d%s, need %d%s", fromKey, have, c.Denom, need, c.Denom)
 		}
 	}
-	// fromKey's inner map is guaranteed non-nil at this point: the check
-	// above only passes when have>=need>0, which means balances[fromKey]
-	// was already initialized when have was read. toKey may still be new.
+	// fromKey's inner map is guaranteed non-nil here: sdk.NewCoins prunes
+	// zero amounts, so every c.Amount is positive, so the validation pass
+	// above only passes when m.balances[fromKey] was already initialized
+	// when have was read. toKey may still be new.
 	for _, c := range amt {
 		amount := nonNegativeAmount(c)
 		if m.balances[toKey] == nil {
@@ -299,9 +300,10 @@ func (m *StatefulBankMock) transfer(fromKey, toKey string, amt sdk.Coins) error 
 	return nil
 }
 
-// copyCoins returns a shallow copy of the slice header so that the
-// caller-supplied amt cannot be mutated post-record. sdk.Coin elements are
-// value-copied; their math.Int internals are immutable.
+// copyCoins returns an independent slice (fresh backing array) holding the
+// same Coin values. After Tasks 3-7 record a BankCall with Amount: copyCoins(amt),
+// callers cannot mutate the recorded amount by mutating their original slice.
+// math.Int amounts are immutable, so element aliasing is safe.
 func copyCoins(amt sdk.Coins) sdk.Coins {
 	out := make(sdk.Coins, len(amt))
 	copy(out, amt)

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -119,20 +119,73 @@ func (m *StatefulBankMock) SendCoins(ctx context.Context, from, to sdk.AccAddres
 	return nil
 }
 
+// SendCoinsFromAccountToModule debits sender, credits the resolved address
+// of recipientModule. Panics if recipientModule is not registered in modAddrs.
 func (m *StatefulBankMock) SendCoinsFromAccountToModule(ctx context.Context, sender sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
-	panic("not implemented")
+	modAddr := m.resolveModule(recipientModule)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fromKey, toKey := sender.String(), modAddr.String()
+	if err := m.transfer(fromKey, toKey, amt); err != nil {
+		return err
+	}
+	m.calls = append(m.calls, BankCall{Method: "SendCoinsFromAccountToModule", From: fromKey, To: toKey, Amount: copyCoins(amt)})
+	return nil
 }
 
+// SendCoinsFromModuleToAccount debits the resolved address of senderModule,
+// credits recipient. Panics if senderModule is not registered.
 func (m *StatefulBankMock) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipient sdk.AccAddress, amt sdk.Coins) error {
-	panic("not implemented")
+	modAddr := m.resolveModule(senderModule)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fromKey, toKey := modAddr.String(), recipient.String()
+	if err := m.transfer(fromKey, toKey, amt); err != nil {
+		return err
+	}
+	m.calls = append(m.calls, BankCall{Method: "SendCoinsFromModuleToAccount", From: fromKey, To: toKey, Amount: copyCoins(amt)})
+	return nil
 }
 
+// SendCoinsFromModuleToModule debits senderModule's resolved address,
+// credits recipientModule's. Panics if either is not registered.
 func (m *StatefulBankMock) SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error {
-	panic("not implemented")
+	fromAddr := m.resolveModule(senderModule)
+	toAddr := m.resolveModule(recipientModule)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fromKey, toKey := fromAddr.String(), toAddr.String()
+	if err := m.transfer(fromKey, toKey, amt); err != nil {
+		return err
+	}
+	m.calls = append(m.calls, BankCall{Method: "SendCoinsFromModuleToModule", From: fromKey, To: toKey, Amount: copyCoins(amt)})
+	return nil
 }
 
+// BurnCoins debits the resolved address of name; nothing is credited
+// elsewhere. Errors atomically with sdkerrors.ErrInsufficientFunds if the
+// module account is short. Panics if name is not registered.
 func (m *StatefulBankMock) BurnCoins(ctx context.Context, name string, amt sdk.Coins) error {
-	panic("not implemented")
+	modAddr := m.resolveModule(name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fromKey := modAddr.String()
+	for _, c := range amt {
+		need := nonNegativeAmount(c)
+		have := int64(0)
+		if d, ok := m.balances[fromKey]; ok {
+			have = d[c.Denom]
+		}
+		if have < need {
+			return sdkerrors.ErrInsufficientFunds.Wrapf(
+				"%s: have %d%s, need %d%s to burn", fromKey, have, c.Denom, need, c.Denom)
+		}
+	}
+	for _, c := range amt {
+		m.balances[fromKey][c.Denom] -= nonNegativeAmount(c)
+	}
+	m.calls = append(m.calls, BankCall{Method: "BurnCoins", From: fromKey, To: "", Amount: copyCoins(amt)})
+	return nil
 }
 
 func (m *StatefulBankMock) HasBalance(ctx context.Context, addr sdk.AccAddress, amt sdk.Coin) bool {

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -1,0 +1,154 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+)
+
+// BankCall records one invocation of a StatefulBankMock send/burn method.
+// From and To are the resolved bech32 addresses (module names are resolved
+// via the modAddrs map at the time of the call). To is empty for BurnCoins.
+type BankCall struct {
+	Method string
+	From   string
+	To     string
+	Amount sdk.Coins
+}
+
+// StatefulBankMock is a stateful test double for the BankKeeper interface
+// used across verana modules. It tracks balances per (addr, denom), enforces
+// deductions, errors on insufficient funds with sdkerrors.ErrInsufficientFunds,
+// and records every send/burn call so tests can assert exact movements.
+//
+// Construct with NewStatefulBankMock and a module-name → module-account-address
+// map (use DefaultModuleAddrs for the standard verana set).
+type StatefulBankMock struct {
+	mu       sync.Mutex
+	balances map[string]map[string]int64 // addr -> denom -> amount
+	baseline map[string]map[string]int64 // addr -> denom -> baseline (set by SetBalance)
+	modAddrs map[string]sdk.AccAddress   // module name -> module account address
+	calls    []BankCall
+}
+
+// NewStatefulBankMock returns a new mock pre-wired with the supplied
+// module-name → module-account-address mapping. Every module name referenced
+// by SendCoinsFromAccountToModule, SendCoinsFromModuleToAccount,
+// SendCoinsFromModuleToModule, or BurnCoins MUST be in modAddrs; unknown
+// names panic to surface test wiring bugs loudly.
+func NewStatefulBankMock(modAddrs map[string]sdk.AccAddress) *StatefulBankMock {
+	return &StatefulBankMock{
+		balances: map[string]map[string]int64{},
+		baseline: map[string]map[string]int64{},
+		modAddrs: modAddrs,
+	}
+}
+
+// DefaultModuleAddrs returns the verana module-name → module-account-address
+// mapping for every module that moves funds, plus the yield_intermediate_pool
+// sub-account used by td. Sourced from authtypes.NewModuleAddress, mirroring
+// what the real app does at startup.
+func DefaultModuleAddrs() map[string]sdk.AccAddress {
+	names := []string{
+		"tr", "cs", "td", "perm", "de", "xr", "di",
+		"gov", "yield_intermediate_pool",
+	}
+	out := make(map[string]sdk.AccAddress, len(names))
+	for _, n := range names {
+		out[n] = authtypes.NewModuleAddress(n)
+	}
+	return out
+}
+
+// --- Mock-only helpers (not part of the BankKeeper interface) ---
+
+func (m *StatefulBankMock) SetBalance(addr sdk.AccAddress, denom string, amount int64) {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) BalanceOf(addr sdk.AccAddress, denom string) int64 {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) Calls() []BankCall {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) RequireBalanceDelta(t require.TestingT, addr sdk.AccAddress, denom string, delta int64) {
+	panic("not implemented")
+}
+
+// --- BankKeeper interface methods ---
+
+func (m *StatefulBankMock) SendCoins(ctx context.Context, from, to sdk.AccAddress, amt sdk.Coins) error {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) SendCoinsFromAccountToModule(ctx context.Context, sender sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipient sdk.AccAddress, amt sdk.Coins) error {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) BurnCoins(ctx context.Context, name string, amt sdk.Coins) error {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) HasBalance(ctx context.Context, addr sdk.AccAddress, amt sdk.Coin) bool {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) GetAllBalances(ctx context.Context, addr sdk.AccAddress) sdk.Coins {
+	panic("not implemented")
+}
+
+func (m *StatefulBankMock) SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins {
+	panic("not implemented")
+}
+
+// resolveModule returns the module account address for name, or panics if
+// the module is not registered in modAddrs.
+func (m *StatefulBankMock) resolveModule(name string) sdk.AccAddress {
+	a, ok := m.modAddrs[name]
+	if !ok {
+		panic(fmt.Sprintf("StatefulBankMock: unknown module %q (register it in NewStatefulBankMock's modAddrs)", name))
+	}
+	return a
+}
+
+// sortedDenoms returns coin denoms sorted ascending — matches sdk.Coins ordering.
+func sortedDenoms(c sdk.Coins) []string {
+	d := make([]string, 0, len(c))
+	for _, coin := range c {
+		d = append(d, coin.Denom)
+	}
+	sort.Strings(d)
+	return d
+}
+
+// nonNegativeAmount returns coin.Amount.Int64() and panics if it would
+// overflow or be negative — sdk.Coins must always be sorted, non-negative.
+func nonNegativeAmount(coin sdk.Coin) int64 {
+	if coin.Amount.IsNegative() {
+		panic(fmt.Sprintf("StatefulBankMock: negative amount for denom %s", coin.Denom))
+	}
+	if !coin.Amount.IsInt64() {
+		panic(fmt.Sprintf("StatefulBankMock: amount for denom %s exceeds int64", coin.Denom))
+	}
+	return coin.Amount.Int64()
+}

--- a/testutil/keeper/bank.go
+++ b/testutil/keeper/bank.go
@@ -285,11 +285,11 @@ func (m *StatefulBankMock) transfer(fromKey, toKey string, amt sdk.Coins) error 
 				"%s: have %d%s, need %d%s", fromKey, have, c.Denom, need, c.Denom)
 		}
 	}
+	// fromKey's inner map is guaranteed non-nil at this point: the check
+	// above only passes when have>=need>0, which means balances[fromKey]
+	// was already initialized when have was read. toKey may still be new.
 	for _, c := range amt {
 		amount := nonNegativeAmount(c)
-		if m.balances[fromKey] == nil {
-			m.balances[fromKey] = map[string]int64{}
-		}
 		if m.balances[toKey] == nil {
 			m.balances[toKey] = map[string]int64{}
 		}

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -1,9 +1,11 @@
 package keeper_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
 	testkeeper "github.com/verana-labs/verana/testutil/keeper"
@@ -78,4 +80,66 @@ func TestSetBalance_PerDenomIsolation(t *testing.T) {
 	m.SetBalance(alice, "ustake", 500)
 	require.Equal(t, int64(1_000), m.BalanceOf(alice, "uvna"))
 	require.Equal(t, int64(500), m.BalanceOf(alice, "ustake"))
+}
+
+// --- Task 3: SendCoins ---
+
+func TestSendCoins_HappyPath(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	m.SetBalance(bob, denom, 200)
+
+	err := m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 300)))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(700), m.BalanceOf(alice, denom))
+	require.Equal(t, int64(500), m.BalanceOf(bob, denom))
+}
+
+func TestSendCoins_MultiCoin(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, "uvna", 1_000)
+	m.SetBalance(alice, "ustake", 500)
+
+	err := m.SendCoins(context.Background(), alice, bob, sdk.NewCoins(
+		sdk.NewInt64Coin("uvna", 100),
+		sdk.NewInt64Coin("ustake", 50),
+	))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(900), m.BalanceOf(alice, "uvna"))
+	require.Equal(t, int64(450), m.BalanceOf(alice, "ustake"))
+	require.Equal(t, int64(100), m.BalanceOf(bob, "uvna"))
+	require.Equal(t, int64(50), m.BalanceOf(bob, "ustake"))
+}
+
+func TestSendCoins_InsufficientFundsDoesNotMutate(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 100)
+	m.SetBalance(bob, denom, 0)
+
+	err := m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 200)))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+
+	require.Equal(t, int64(100), m.BalanceOf(alice, denom))
+	require.Equal(t, int64(0), m.BalanceOf(bob, denom))
+}
+
+func TestSendCoins_InsufficientOnSecondDenomDoesNotMutateFirst(t *testing.T) {
+	// Atomicity: if the second coin has insufficient funds, the first must
+	// NOT be debited. Otherwise tests can't reason about partial state.
+	m := newMock(t)
+	m.SetBalance(alice, "uvna", 1_000)
+	m.SetBalance(alice, "ustake", 10)
+
+	err := m.SendCoins(context.Background(), alice, bob, sdk.NewCoins(
+		sdk.NewInt64Coin("uvna", 100),
+		sdk.NewInt64Coin("ustake", 50),
+	))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.Equal(t, int64(1_000), m.BalanceOf(alice, "uvna"))
+	require.Equal(t, int64(10), m.BalanceOf(alice, "ustake"))
+	require.Equal(t, int64(0), m.BalanceOf(bob, "uvna"))
 }

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -52,10 +52,5 @@ func (c *captureT) Errorf(format string, args ...interface{}) {
 }
 func (c *captureT) FailNow() { c.failed = true }
 
-// Suppress unused-variable warnings for package-level vars used by future tasks.
-var (
-	_ = denom
-	_ = alice
-	_ = bob
-	_ require.TestingT = (*captureT)(nil)
-)
+// Compile-time assertion: captureT implements require.TestingT.
+var _ require.TestingT = (*captureT)(nil)

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -1,0 +1,61 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	testkeeper "github.com/verana-labs/verana/testutil/keeper"
+	cstypes "github.com/verana-labs/verana/x/cs/types"
+	detypes "github.com/verana-labs/verana/x/de/types"
+	ditypes "github.com/verana-labs/verana/x/di/types"
+	permtypes "github.com/verana-labs/verana/x/perm/types"
+	tdtypes "github.com/verana-labs/verana/x/td/types"
+	trtypes "github.com/verana-labs/verana/x/tr/types"
+	xrtypes "github.com/verana-labs/verana/x/xr/types"
+)
+
+// Compile-time assertions: StatefulBankMock satisfies every module's
+// BankKeeper interface. If any module's interface grows, these will fail.
+var (
+	_ permtypes.BankKeeper = (*testkeeper.StatefulBankMock)(nil)
+	_ tdtypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+	_ cstypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+	_ trtypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+	_ detypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+	_ xrtypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+	_ ditypes.BankKeeper   = (*testkeeper.StatefulBankMock)(nil)
+)
+
+// Test addresses, reused across tests.
+var (
+	denom = "uvna"
+	alice = sdk.AccAddress([]byte("alice_______________"))
+	bob   = sdk.AccAddress([]byte("bob_________________"))
+)
+
+func newMock(t *testing.T) *testkeeper.StatefulBankMock {
+	t.Helper()
+	return testkeeper.NewStatefulBankMock(testkeeper.DefaultModuleAddrs())
+}
+
+// captureT implements require.TestingT and records whether an assertion
+// would have failed. Used to test RequireBalanceDelta itself.
+type captureT struct {
+	failed bool
+	last   string
+}
+
+func (c *captureT) Errorf(format string, args ...interface{}) {
+	c.failed = true
+}
+func (c *captureT) FailNow() { c.failed = true }
+
+// Suppress unused-variable warnings for package-level vars used by future tasks.
+var (
+	_ = denom
+	_ = alice
+	_ = bob
+	_ require.TestingT = (*captureT)(nil)
+)

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -478,4 +479,44 @@ func TestRequireBalanceDelta_RebaselinesOnSetBalance(t *testing.T) {
 
 	m.SetBalance(alice, denom, 5_000) // new baseline
 	m.RequireBalanceDelta(t, alice, denom, 0)
+}
+
+// --- Task 11: Concurrency safety ---
+
+func TestStatefulBankMock_ConcurrentTransfersAreRaceFree(t *testing.T) {
+	m := newMock(t)
+	addrs := make([]sdk.AccAddress, 16)
+	for i := range addrs {
+		var a [20]byte
+		a[0] = byte(i)
+		addrs[i] = sdk.AccAddress(a[:])
+		m.SetBalance(addrs[i], denom, 1_000_000)
+	}
+
+	const workers = 8
+	const ops = 200
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < ops; i++ {
+				from := addrs[(w+i)%len(addrs)]
+				to := addrs[(w+i+1)%len(addrs)]
+				_ = m.SendCoins(context.Background(), from, to,
+					sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+				_ = m.HasBalance(context.Background(), from, sdk.NewInt64Coin(denom, 1))
+				_ = m.GetAllBalances(context.Background(), to)
+				_ = m.Calls()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Conservation: total amount across all addrs is unchanged.
+	var total int64
+	for _, a := range addrs {
+		total += m.BalanceOf(a, denom)
+	}
+	require.Equal(t, int64(16_000_000), total)
 }

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -288,3 +288,194 @@ func TestBurnCoins_UnknownModulePanics(t *testing.T) {
 			sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
 	})
 }
+
+// --- Task 8: read methods ---
+
+func TestHasBalance_TrueWhenSufficient(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 100)
+	require.True(t, m.HasBalance(context.Background(), alice, sdk.NewInt64Coin(denom, 100)))
+	require.True(t, m.HasBalance(context.Background(), alice, sdk.NewInt64Coin(denom, 50)))
+}
+
+func TestHasBalance_FalseWhenInsufficient(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 100)
+	require.False(t, m.HasBalance(context.Background(), alice, sdk.NewInt64Coin(denom, 101)))
+	require.False(t, m.HasBalance(context.Background(), bob, sdk.NewInt64Coin(denom, 1)))
+}
+
+func TestGetBalance_ReflectsState(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 250)
+	got := m.GetBalance(context.Background(), alice, denom)
+	require.Equal(t, denom, got.Denom)
+	require.Equal(t, int64(250), got.Amount.Int64())
+}
+
+func TestGetBalance_UnsetIsZeroCoin(t *testing.T) {
+	m := newMock(t)
+	got := m.GetBalance(context.Background(), alice, denom)
+	require.Equal(t, denom, got.Denom)
+	require.True(t, got.Amount.IsZero())
+}
+
+func TestGetAllBalances_AllDenoms(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, "uvna", 100)
+	m.SetBalance(alice, "ustake", 50)
+
+	got := m.GetAllBalances(context.Background(), alice)
+	require.Equal(t, sdk.NewCoins(
+		sdk.NewInt64Coin("uvna", 100),
+		sdk.NewInt64Coin("ustake", 50),
+	), got)
+}
+
+func TestGetAllBalances_UnsetReturnsEmpty(t *testing.T) {
+	m := newMock(t)
+	require.Empty(t, m.GetAllBalances(context.Background(), alice))
+}
+
+func TestGetAllBalances_SkipsZero(t *testing.T) {
+	// After a transfer that drains a denom to zero, GetAllBalances should
+	// not surface the zero entry — sdk.Coins is canonically sorted with
+	// only non-zero amounts.
+	m := newMock(t)
+	m.SetBalance(alice, denom, 100)
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 100))))
+
+	got := m.GetAllBalances(context.Background(), alice)
+	require.Empty(t, got)
+}
+
+func TestSpendableCoins_MatchesGetAllBalances(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, "uvna", 100)
+	m.SetBalance(alice, "ustake", 50)
+	require.Equal(t, m.GetAllBalances(context.Background(), alice),
+		m.SpendableCoins(context.Background(), alice))
+}
+
+// --- Task 9: Calls() accessor and call-recording verification ---
+
+func TestCalls_Empty(t *testing.T) {
+	m := newMock(t)
+	require.Empty(t, m.Calls())
+}
+
+func TestCalls_RecordsEachMethodInOrder(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 10_000)
+	tdAddr := authtypes.NewModuleAddress("td")
+	yipAddr := authtypes.NewModuleAddress("yield_intermediate_pool")
+	m.SetBalance(tdAddr, denom, 10_000)
+	m.SetBalance(yipAddr, denom, 0)
+
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 10))))
+	require.NoError(t, m.SendCoinsFromAccountToModule(context.Background(), alice, "td",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 20))))
+	require.NoError(t, m.SendCoinsFromModuleToAccount(context.Background(), "td", bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 30))))
+	require.NoError(t, m.SendCoinsFromModuleToModule(context.Background(), "td", "yield_intermediate_pool",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 40))))
+	require.NoError(t, m.BurnCoins(context.Background(), "td",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 50))))
+
+	calls := m.Calls()
+	require.Len(t, calls, 5)
+	require.Equal(t, "SendCoins", calls[0].Method)
+	require.Equal(t, alice.String(), calls[0].From)
+	require.Equal(t, bob.String(), calls[0].To)
+	require.Equal(t, sdk.NewCoins(sdk.NewInt64Coin(denom, 10)), calls[0].Amount)
+
+	require.Equal(t, "SendCoinsFromAccountToModule", calls[1].Method)
+	require.Equal(t, tdAddr.String(), calls[1].To)
+
+	require.Equal(t, "SendCoinsFromModuleToAccount", calls[2].Method)
+	require.Equal(t, tdAddr.String(), calls[2].From)
+	require.Equal(t, bob.String(), calls[2].To)
+
+	require.Equal(t, "SendCoinsFromModuleToModule", calls[3].Method)
+	require.Equal(t, tdAddr.String(), calls[3].From)
+	require.Equal(t, yipAddr.String(), calls[3].To)
+
+	require.Equal(t, "BurnCoins", calls[4].Method)
+	require.Equal(t, tdAddr.String(), calls[4].From)
+	require.Equal(t, "", calls[4].To)
+}
+
+func TestCalls_FailedTransferIsNotRecorded(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1)
+	err := m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 100)))
+	require.Error(t, err)
+	require.Empty(t, m.Calls(), "failed transfers must not appear in call history")
+}
+
+func TestCalls_ReturnsCopyNotInternalSlice(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 100)
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 1))))
+
+	c1 := m.Calls()
+	c1[0].Method = "tampered"
+
+	c2 := m.Calls()
+	require.Equal(t, "SendCoins", c2[0].Method, "Calls() must return a defensive copy")
+}
+
+// --- Task 10: RequireBalanceDelta ---
+
+func TestRequireBalanceDelta_NoChange(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	m.RequireBalanceDelta(t, alice, denom, 0)
+}
+
+func TestRequireBalanceDelta_NegativeAfterSend(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	m.SetBalance(bob, denom, 0)
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 300))))
+	m.RequireBalanceDelta(t, alice, denom, -300)
+	m.RequireBalanceDelta(t, bob, denom, +300)
+}
+
+func TestRequireBalanceDelta_UnsetBaselineTreatedAsZero(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 500)
+	require.NoError(t, m.SendCoinsFromAccountToModule(context.Background(), alice, "perm",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 200))))
+	// perm module addr was never SetBalance'd → baseline 0 → delta +200.
+	m.RequireBalanceDelta(t, authtypes.NewModuleAddress("perm"), denom, +200)
+}
+
+func TestRequireBalanceDelta_FailsOnWrongDelta(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	m.SetBalance(bob, denom, 0)
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 300))))
+
+	cap := &captureT{}
+	m.RequireBalanceDelta(cap, alice, denom, -100) // wrong: actual is -300
+	require.True(t, cap.failed, "RequireBalanceDelta must fail on wrong delta")
+}
+
+func TestRequireBalanceDelta_RebaselinesOnSetBalance(t *testing.T) {
+	// Calling SetBalance again resets the baseline.
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	require.NoError(t, m.SendCoins(context.Background(), alice, bob,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 100))))
+	require.Equal(t, int64(900), m.BalanceOf(alice, denom))
+
+	m.SetBalance(alice, denom, 5_000) // new baseline
+	m.RequireBalanceDelta(t, alice, denom, 0)
+}

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -44,13 +44,10 @@ func newMock(t *testing.T) *testkeeper.StatefulBankMock {
 // would have failed. Used to test RequireBalanceDelta itself.
 type captureT struct {
 	failed bool
-	last   string
 }
 
-func (c *captureT) Errorf(format string, args ...interface{}) {
-	c.failed = true
-}
-func (c *captureT) FailNow() { c.failed = true }
+func (c *captureT) Errorf(format string, args ...interface{}) { c.failed = true }
+func (c *captureT) FailNow()                                  { c.failed = true }
 
 // Compile-time assertion: captureT implements require.TestingT.
 var _ require.TestingT = (*captureT)(nil)

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -479,6 +480,28 @@ func TestRequireBalanceDelta_RebaselinesOnSetBalance(t *testing.T) {
 
 	m.SetBalance(alice, denom, 5_000) // new baseline
 	m.RequireBalanceDelta(t, alice, denom, 0)
+}
+
+// --- Defensive-guard panic paths ---
+
+func TestSendCoins_NegativeAmountPanics(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	bad := sdk.Coins{sdk.Coin{Denom: denom, Amount: math.NewInt(-1)}}
+	require.Panics(t, func() {
+		_ = m.SendCoins(context.Background(), alice, bob, bad)
+	})
+}
+
+func TestSendCoins_OverflowAmountPanics(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	huge, ok := math.NewIntFromString("18446744073709551616") // 2^64
+	require.True(t, ok)
+	bad := sdk.Coins{sdk.Coin{Denom: denom, Amount: huge}}
+	require.Panics(t, func() {
+		_ = m.SendCoins(context.Background(), alice, bob, bad)
+	})
 }
 
 // --- Task 11: Concurrency safety ---

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -51,3 +51,31 @@ func (c *captureT) FailNow()                                  { c.failed = true 
 
 // Compile-time assertion: captureT implements require.TestingT.
 var _ require.TestingT = (*captureT)(nil)
+
+// --- Task 2: SetBalance and BalanceOf ---
+
+func TestSetBalance_GetSet(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	require.Equal(t, int64(1_000), m.BalanceOf(alice, denom))
+}
+
+func TestSetBalance_OverwritesPreviousValue(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	m.SetBalance(alice, denom, 2_500)
+	require.Equal(t, int64(2_500), m.BalanceOf(alice, denom))
+}
+
+func TestBalanceOf_UnsetReturnsZero(t *testing.T) {
+	m := newMock(t)
+	require.Equal(t, int64(0), m.BalanceOf(alice, denom))
+}
+
+func TestSetBalance_PerDenomIsolation(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, "uvna", 1_000)
+	m.SetBalance(alice, "ustake", 500)
+	require.Equal(t, int64(1_000), m.BalanceOf(alice, "uvna"))
+	require.Equal(t, int64(500), m.BalanceOf(alice, "ustake"))
+}

--- a/testutil/keeper/bank_test.go
+++ b/testutil/keeper/bank_test.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 
 	testkeeper "github.com/verana-labs/verana/testutil/keeper"
@@ -142,4 +143,148 @@ func TestSendCoins_InsufficientOnSecondDenomDoesNotMutateFirst(t *testing.T) {
 	require.Equal(t, int64(1_000), m.BalanceOf(alice, "uvna"))
 	require.Equal(t, int64(10), m.BalanceOf(alice, "ustake"))
 	require.Equal(t, int64(0), m.BalanceOf(bob, "uvna"))
+}
+
+// --- Task 4: SendCoinsFromAccountToModule ---
+
+func TestSendCoinsFromAccountToModule_HappyPath(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	modAddr := authtypes.NewModuleAddress("perm")
+
+	err := m.SendCoinsFromAccountToModule(context.Background(), alice, "perm",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 300)))
+	require.NoError(t, err)
+
+	require.Equal(t, int64(700), m.BalanceOf(alice, denom))
+	require.Equal(t, int64(300), m.BalanceOf(modAddr, denom))
+}
+
+func TestSendCoinsFromAccountToModule_InsufficientFunds(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 50)
+
+	err := m.SendCoinsFromAccountToModule(context.Background(), alice, "perm",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 300)))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.Equal(t, int64(50), m.BalanceOf(alice, denom))
+	require.Equal(t, int64(0), m.BalanceOf(authtypes.NewModuleAddress("perm"), denom))
+}
+
+func TestSendCoinsFromAccountToModule_UnknownModulePanics(t *testing.T) {
+	m := newMock(t)
+	m.SetBalance(alice, denom, 1_000)
+	require.PanicsWithValue(t,
+		`StatefulBankMock: unknown module "no_such_mod" (register it in NewStatefulBankMock's modAddrs)`,
+		func() {
+			_ = m.SendCoinsFromAccountToModule(context.Background(), alice, "no_such_mod",
+				sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+		})
+}
+
+// --- Task 5: SendCoinsFromModuleToAccount ---
+
+func TestSendCoinsFromModuleToAccount_HappyPath(t *testing.T) {
+	m := newMock(t)
+	modAddr := authtypes.NewModuleAddress("td")
+	m.SetBalance(modAddr, denom, 5_000)
+
+	err := m.SendCoinsFromModuleToAccount(context.Background(), "td", alice,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 1_200)))
+	require.NoError(t, err)
+	require.Equal(t, int64(3_800), m.BalanceOf(modAddr, denom))
+	require.Equal(t, int64(1_200), m.BalanceOf(alice, denom))
+}
+
+func TestSendCoinsFromModuleToAccount_InsufficientFunds(t *testing.T) {
+	m := newMock(t)
+	modAddr := authtypes.NewModuleAddress("td")
+	m.SetBalance(modAddr, denom, 100)
+
+	err := m.SendCoinsFromModuleToAccount(context.Background(), "td", alice,
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 200)))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.Equal(t, int64(100), m.BalanceOf(modAddr, denom))
+	require.Equal(t, int64(0), m.BalanceOf(alice, denom))
+}
+
+func TestSendCoinsFromModuleToAccount_UnknownModulePanics(t *testing.T) {
+	m := newMock(t)
+	require.Panics(t, func() {
+		_ = m.SendCoinsFromModuleToAccount(context.Background(), "ghost", alice,
+			sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+	})
+}
+
+// --- Task 6: SendCoinsFromModuleToModule ---
+
+func TestSendCoinsFromModuleToModule_HappyPath(t *testing.T) {
+	m := newMock(t)
+	tdAddr := authtypes.NewModuleAddress("td")
+	yipAddr := authtypes.NewModuleAddress("yield_intermediate_pool")
+	m.SetBalance(tdAddr, denom, 10_000)
+
+	err := m.SendCoinsFromModuleToModule(context.Background(), "td", "yield_intermediate_pool",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 4_000)))
+	require.NoError(t, err)
+	require.Equal(t, int64(6_000), m.BalanceOf(tdAddr, denom))
+	require.Equal(t, int64(4_000), m.BalanceOf(yipAddr, denom))
+}
+
+func TestSendCoinsFromModuleToModule_InsufficientFunds(t *testing.T) {
+	m := newMock(t)
+	tdAddr := authtypes.NewModuleAddress("td")
+	m.SetBalance(tdAddr, denom, 50)
+
+	err := m.SendCoinsFromModuleToModule(context.Background(), "td", "yield_intermediate_pool",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 100)))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+}
+
+func TestSendCoinsFromModuleToModule_UnknownSenderPanics(t *testing.T) {
+	m := newMock(t)
+	require.Panics(t, func() {
+		_ = m.SendCoinsFromModuleToModule(context.Background(), "ghost", "td",
+			sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+	})
+}
+
+func TestSendCoinsFromModuleToModule_UnknownRecipientPanics(t *testing.T) {
+	m := newMock(t)
+	require.Panics(t, func() {
+		_ = m.SendCoinsFromModuleToModule(context.Background(), "td", "ghost",
+			sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+	})
+}
+
+// --- Task 7: BurnCoins ---
+
+func TestBurnCoins_HappyPath(t *testing.T) {
+	m := newMock(t)
+	tdAddr := authtypes.NewModuleAddress("td")
+	m.SetBalance(tdAddr, denom, 5_000)
+
+	err := m.BurnCoins(context.Background(), "td",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 1_500)))
+	require.NoError(t, err)
+	require.Equal(t, int64(3_500), m.BalanceOf(tdAddr, denom))
+}
+
+func TestBurnCoins_InsufficientFunds(t *testing.T) {
+	m := newMock(t)
+	tdAddr := authtypes.NewModuleAddress("td")
+	m.SetBalance(tdAddr, denom, 100)
+
+	err := m.BurnCoins(context.Background(), "td",
+		sdk.NewCoins(sdk.NewInt64Coin(denom, 1_000)))
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFunds)
+	require.Equal(t, int64(100), m.BalanceOf(tdAddr, denom))
+}
+
+func TestBurnCoins_UnknownModulePanics(t *testing.T) {
+	m := newMock(t)
+	require.Panics(t, func() {
+		_ = m.BurnCoins(context.Background(), "ghost",
+			sdk.NewCoins(sdk.NewInt64Coin(denom, 1)))
+	})
 }


### PR DESCRIPTION
Umbrella PR for issue #292 — the comprehensive behavioral test overhaul. Each step lands as a separate commit (or small commit set) on this branch. This PR will accumulate Steps 0–34 from the design doc; merging happens once the full overhaul is in.

Spec: [docs/superpowers/specs/2026-05-05-comprehensive-test-overhaul-design.md](../blob/test/behavioral-test-overhaul/docs/superpowers/specs/2026-05-05-comprehensive-test-overhaul-design.md)
Step 0 plan: [docs/superpowers/plans/2026-05-06-step-0-stateful-bank-mock.md](../blob/test/behavioral-test-overhaul/docs/superpowers/plans/2026-05-06-step-0-stateful-bank-mock.md)

## Currently landed

### Step 0 — `StatefulBankMock` (the gate)

New `testutil/keeper/bank.go` + `bank_test.go`. Replaces the no-op `MockBankKeeper` with a stateful test double that tracks balances, enforces deductions, errors atomically with `sdkerrors.ErrInsufficientFunds`, records call history for assertions, and exposes `RequireBalanceDelta` for spec-anchored fee checks.

- Implements every module's `BankKeeper` interface (compile-time assertions for all 7 modules: perm, td, cs, tr, de, xr, di)
- `DefaultModuleAddrs()` covers tr, cs, td, perm, de, xr, di, gov, yield_intermediate_pool
- Atomic insufficient-funds: `transfer` validates every denom before mutating any
- Race-detector clean (dedicated stress test)
- 100% per-function coverage on `bank.go`
- Legacy no-op `MockBankKeeper` intentionally untouched per migration policy

## Pending steps (from design doc)

| Step | Module / Work | Type |
|------|-----------|------|
| 1–4 | TD: ReclaimTrustDepositYield, SlashTrustDeposit, RepaySlashedTrustDeposit, BurnEcosystemSlashedTrustDeposit | Unit |
| 5 | TS #286: sign mode fix + permRenewPermissionVP.ts | TS-proto |
| 6–10 | TR: 5 messages | Unit |
| 11–16 | CS: 6 messages | Unit |
| 17–20 | DE: 4 messages | Unit |
| 21–31 | PERM: 11 messages | Unit |
| 32 | XR: 3 messages | Unit |
| 33 | DI: StoreDigest | Unit |
| 34 | TS-proto journey gaps | TS-proto |

## Test plan
- [x] `go test ./...` clean
- [x] `go test ./testutil/keeper/ -race` clean
- [x] `go vet ./testutil/keeper/...` clean
- [x] `bank.go` per-function coverage 100%
- [x] Legacy `MockBankKeeper` untouched (`git diff main..HEAD -- testutil/keeper/credentialschema.go` empty)
- [ ] Steps 1–34 land as additional commits before un-drafting